### PR TITLE
Adds head repository to rcm

### DIFF
--- a/Formula/rcm.rb
+++ b/Formula/rcm.rb
@@ -4,6 +4,7 @@ class Rcm < Formula
   homepage 'http://thoughtbot.github.io/rcm'
   url 'https://github.com/thoughtbot/rcm/archive/v1.2.0.tar.gz'
   sha1 'b512a2f3d4d81e726e685c4807c4167c232fb09c'
+  head 'https://github.com/thoughtbot/rcm.git'
 
   depends_on "autoconf"
   depends_on "automake"


### PR DESCRIPTION
The rcm repository has had changes, and I'd like to keep up with the latest revisions. This pull request adds a `head` revision line to the formula to enable this if the user wishes.
