### PR TITLE
Add a formula for croaky/parity

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -1,0 +1,24 @@
+require "formula"
+
+class Parity < Formula
+  homepage "https://github.com/croaky/parity"
+  url "https://github.com/croaky/parity/archive/v0.3.0.tar.gz"
+  sha1 "f07b33958067d719a4487243cae10c5f6e1b379c"
+
+  depends_on "heroku-toolbelt"
+
+  def install
+    # Add the lib/ directory to the Ruby load path at the top of the file
+    inreplace "lib/parity.rb", /\A/, "$LOAD_PATH << File.dirname(__FILE__)\n\n"
+
+    prefix.install "lib" => "lib"
+
+    bin.install "bin/development", "bin/staging", "bin/production"
+  end
+
+  test do
+    system "#{bin}/development", "--version"
+    system "#{bin}/staging", "--version"
+    system "#{bin}/production", "--version"
+  end
+end


### PR DESCRIPTION
croaky/parity shouldn't be a Rubygem - I have to do `gem install parity` all
the time. It should be a system-level utility. Enough of thoughtbot uses it
that I feel comfortable maintaining the formula in this repository.
