### PR TITLE
No need to fiddle with parity's $LOADPATH

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -9,9 +9,6 @@ class Parity < Formula
   depends_on "heroku-toolbelt"
 
   def install
-    # Add the lib/ directory to the Ruby load path at the top of the file
-    inreplace "lib/parity.rb", /\A/, "$LOAD_PATH << File.dirname(__FILE__)\n\n"
-
     prefix.install "lib" => "lib"
 
     bin.install "bin/development", "bin/staging", "bin/production"


### PR DESCRIPTION
`brew upgrade parity` (from 0.3.1) gave me this result:

```
==> Upgrading 1 outdated package, with result:
parity 0.5.0
==> Upgrading parity
==> Downloading https://github.com/croaky/parity/releases/download/v0.5.0/parity-0.5.0-osx.tar.gz
Already downloaded: /Library/Caches/Homebrew/parity-0.5.0.tar.gz
Error: No such file or directory - lib/parity.rb
```

The fix is to just not touch `lib/parity.rb`, since it runs without it.