### PR TITLE
Add Git and Postgres as Parity dependencies

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -6,7 +6,9 @@ class Parity < Formula
   version "0.7.0"
   sha256 "3c9b9bf2a950c7a18e67800bdd6676cb415dd17a3acb4189a85184804d403f33"
 
+  depends_on "git"
   depends_on "heroku-toolbelt"
+  depends_on "postgres"
 
   def install
     prefix.install "lib" => "lib"


### PR DESCRIPTION
Postgres is used by these commands:

* `development restore production`
* `development restore staging`

Git is used by these commands:

* `production deploy`
* `staging deploy`