### PR TITLE
Force Parity update to v0.9.2

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -3,7 +3,7 @@ require "formula"
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
   url "https://github.com/thoughtbot/parity/releases/download/v0.9.2/parity-0.9.2-osx.tar.gz"
-  version "0.9.2"
+  version "0.9.2.1"
   sha256 "d56827ce379958b5abe386f6afff3b012275f43a6d982f524c54bb8a790cee20"
 
   depends_on "git"


### PR DESCRIPTION
The update in 1e71d00e0c3f784d42f458a1558c38eb30b289f5 referenced a bad
URL for the v0.9.2 package. We've updated it in
4dc62a0f3710d008a38c4a51fc5e939a1c788a91, but it's not clear that users
who have already upgraded will still get 0.9.2.

Building a v0.9.2.1 package so that Homebrew users see the v0.9.2 update
as a new version and receive the newest package.