### PR TITLE
Add libxcproj version 0.0.1

### DIFF
--- a/Formula/libxcproj.rb
+++ b/Formula/libxcproj.rb
@@ -1,0 +1,25 @@
+class Libxcproj < Formula
+  desc "Library for manipulating Xcode project files"
+  homepage "https://github.com/thoughtbot/libxproj"
+  url "https://github.com/thoughtbot/libxcproj/archive/0.0.1.tar.gz"
+  sha256 "83d6ea9dc98b9421e4e4453fa05aeddf7ab7108a78b8a6c8cc7a711027f36d49"
+
+  def install
+    xcodebuild "-target", "libxcproj", "install", "DSTROOT=#{prefix}", "SYMROOT=build"
+  end
+
+  test do
+    (testpath/"test.m").write <<-EOS.undent
+      #import <xcproj/Xcproj.h>
+
+      int main(void) {
+        [Xcproj loadFrameworks:NULL];
+        id<PBXProject> project = [PBXProject new];
+        NSLog(@"%@", project);
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-lxcproj", "test.m"
+    system "./a.out"
+  end
+end


### PR DESCRIPTION
`libxcproj` is a fork of [0xced/xcproj](https://github.com/0xced/xcproj) that removes the command line tool, in favour of a static library that can provide a foundation for any tool to interact with Xcode project files.

Rationale: https://gist.github.com/sharplet/33b7a76907e1aa1d3465

This is a very early version that does the bare minimum to distribute a static library. Future releases will likely focus on proper Swift support, and possibly wrapping the private Xcode frameworks in a stable public API.