### PR TITLE
Create development version of Parity forumla

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
-  url "https://github.com/thoughtbot/parity/releases/download/v0.9.2/parity-0.9.2-osx.tar.gz"
-  version "0.9.2.1"
   sha256 "d56827ce379958b5abe386f6afff3b012275f43a6d982f524c54bb8a790cee20"
+  url "https://github.com/thoughtbot/parity/releases/download/v0.9.2/parity-0.9.1-osx.tar.gz"
+  version "0.9.2"
 
   depends_on "git"
   depends_on "heroku-toolbelt"
@@ -16,9 +16,17 @@ class Parity < Formula
     bin.install "bin/development", "bin/staging", "bin/production"
   end
 
+  devel do
+    url "https://github.com/thoughtbot/parity/releases/download/v0.9.3.beta/parity-0.9.3.beta-osx.tar.gz"
+
+    depends_on "git"
+    depends_on "heroku-toolbelt"
+    depends_on "postgres"
+  end
+
   test do
     system "#{bin}/development", "--version"
-    system "#{bin}/staging", "--version"
     system "#{bin}/production", "--version"
+    system "#{bin}/staging", "--version"
   end
 end


### PR DESCRIPTION
This change adds a `devel` version of the Parity forumla that can be
used to test the packaged executables without pushing a new version
prematurely to users.

Documentation:
https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md#unstable-versions-devel-head