### PR TITLE
Update Parity formula to v0.9.3

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -2,22 +2,22 @@ require "formula"
 
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
-  sha256 "d56827ce379958b5abe386f6afff3b012275f43a6d982f524c54bb8a790cee20"
-  url "https://github.com/thoughtbot/parity/releases/download/v0.9.2/parity-0.9.2-osx.tar.gz"
-  version "0.9.2.1"
+  sha256 "438b15beb0f0e0fd8da1aee5cc47ca57ff03c138091100d30fe5ae90a0f22c22"
+  url "https://github.com/thoughtbot/parity/releases/download/0.9.3/parity-0.9.3-osx.tar.gz"
+  version "0.9.3"
 
   depends_on "git"
   depends_on "heroku-toolbelt"
   depends_on "postgres"
 
   def install
-    prefix.install "lib" => "lib"
+    lib.install Dir["lib/*"]
 
     bin.install "bin/development", "bin/staging", "bin/production"
   end
 
   devel do
-    url "https://github.com/thoughtbot/parity/releases/download/v0.9.3.beta/parity-0.9.3.beta-osx.tar.gz"
+    url "https://github.com/thoughtbot/parity/releases/download/development/parity-development.tar.gz"
 
     depends_on "git"
     depends_on "heroku-toolbelt"


### PR DESCRIPTION
The prior version of the formula did not recursively copy the contents
of `lib`, which left out the `Gemfile.lock` and vendored gems required
to use newer versions of Parity.