### PR TITLE
Switch formula to use SHA256 checksum

### DIFF
--- a/Formula/gitsh.rb
+++ b/Formula/gitsh.rb
@@ -6,7 +6,7 @@ class Gitsh < Formula
 
   homepage 'https://github.com/thoughtbot/gitsh'
   url 'http://thoughtbot.github.io/gitsh/gitsh-0.10.tar.gz'
-  sha1 'f3b62fb6bf6b7cce003df6324512f67cdc3a9061'
+  sha256 '538558c2f385efc6130ef4e412776055820417c5c87483dbf3568bf31f1f09e3'
 
   def self.old_system_ruby?
     system_ruby_version = `#{SYSTEM_RUBY_PATH} -e "puts RUBY_VERSION"`.chomp

--- a/Formula/liftoff.rb
+++ b/Formula/liftoff.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Liftoff < Formula
   homepage 'https://github.com/thoughtbot/liftoff'
   url 'http://thoughtbot.github.io/liftoff/Liftoff-1.6.0.tar.gz'
-  sha1 'e7b1baf1124cf70da5f178da6c6a3fe6e79ced87'
+  sha256 'e532a7701720513cca82bdbda6cf5f609cffd2726072b5bd5456a24662639cfa'
 
   depends_on 'xcproj' => :recommended
 

--- a/Formula/pick.rb
+++ b/Formula/pick.rb
@@ -3,7 +3,7 @@ require "formula"
 class Pick < Formula
   homepage "http://thoughtbot.github.io/pick/"
   url "https://github.com/thoughtbot/pick/releases/download/v1.3.0/pick-1.3.0.tar.gz"
-  sha1 "87f7d24ad859bc059f5c5a9bb41f4697e4979bd8"
+  sha256 "a1c2c7902f6a322d7be5cf024d6cb94f1e65edfbba4b151647d215481f783257"
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/rcm.rb
+++ b/Formula/rcm.rb
@@ -2,7 +2,7 @@ class Rcm < Formula
   desc "management suite for dotfiles"
   homepage "https://thoughtbot.github.io/rcm"
   url "https://thoughtbot.github.io/rcm/dist/rcm-1.3.0.tar.gz"
-  sha1 "10a04bf8a299f7a4991006e65a7d8fb95615565b"
+  sha256 "ddcf638b367b0361d8e063c29fd573dbe1712d1b83e8d5b3a868e4aa45ffc847"
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",


### PR DESCRIPTION
Noticed the following deprecation message when installing `rcm`. 

> SHA1 support is deprecated and will be removed in a future version.
> Please switch this formula to SHA256.

([source](https://github.com/Homebrew/legacy-homebrew/blob/master/Library/Homebrew/compat/sha1.rb#L30))

This PR proposes to switch the formula currently using a `SHA1` generated checksum to use `SHA256`. 

**Please note:**
The checksum values were generated by downloading the URL listed in the formula to my machine and running: `shasum -a 256 /path/to/file.tar.gz`. I would recommend someone at Thoughtbot may wish to verify these values are correct before accepting this PR.

Thanks for provides these formula btw. ❤️ 