### PR TITLE
Fix deprecated Hardware.is_64_bit on paperback

### DIFF
--- a/Formula/paperback.rb
+++ b/Formula/paperback.rb
@@ -2,9 +2,9 @@ require "formula"
 
 class Paperback < Formula
   homepage ""
-  version "0.1.1"
+  version "0.1.2"
 
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url "https://s3.amazonaws.com/homebrew-formulae/go-paperback_v0.1.1_darwin_amd64.tar.gz"
     sha256 "4d143ffc7333b5ec25d555ef99f69c0b8602b9a4f3104fcdaea34ffb35002aaf"
   end


### PR DESCRIPTION
Fix the following warning message on tap:
```
Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
```