### PR TITLE
Remove deprecated method Hardware.is_64_bit?

### DIFF
--- a/Formula/paperback.rb
+++ b/Formula/paperback.rb
@@ -4,7 +4,7 @@ class Paperback < Formula
   homepage ""
   version "0.1.1"
 
-  if Hardware.is_64_bit?
+  if Hardware::CPU.is_64_bit?
     url "https://s3.amazonaws.com/homebrew-formulae/go-paperback_v0.1.1_darwin_amd64.tar.gz"
     sha256 "4d143ffc7333b5ec25d555ef99f69c0b8602b9a4f3104fcdaea34ffb35002aaf"
   end


### PR DESCRIPTION
```
==> Tapping thoughtbot/formulae
Cloning into '/usr/local/Library/Taps/thoughtbot/homebrew-formulae'...
remote: Counting objects: 12, done.
remote: Compressing objects: 100% (12/12), done.
remote: Total 12 (delta 0), reused 6 (delta 0), pack-reused 0
Unpacking objects: 100% (12/12), done.
Checking connectivity... done.
Warning: Calling Hardware.is_64_bit? is deprecated!
Use Hardware::CPU.is_64_bit? instead.
/usr/local/Library/Taps/thoughtbot/homebrew-formulae/Formula/paperback.rb:7:in `<class:Paperback>'
Please report this to the thoughtbot/formulae tap!
```