### PR TITLE
Updates link to brew-tap documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A [Homebrew tap] for various thoughtbot projects.
 
-[Homebrew tap]: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md
+[Homebrew tap]: https://github.com/Homebrew/brew/blob/master/docs/brew-tap.md
 
 ## Usage
 


### PR DESCRIPTION
The current link to the brew-tap documentation points to the legacy
repository. This commit updates the `README` to link to the new
repository.