### PR TITLE
Parity v2.0.1

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -2,13 +2,13 @@ require "formula"
 
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
-  sha256 "822292a9a2ccb05c592d4da311820e1252ba7363b9f78b7ba0c75469df508460"
-  url "https://github.com/thoughtbot/parity/releases/download/v1.0.0/parity-1.0.0-osx.tar.gz"
-  version "1.0.0"
+  sha256 "693e2f05ba5eccca7a526be7ae0afc25dcddea6ad55cd998bc9b6935920920f0"
+  url "https://github.com/thoughtbot/parity/releases/download/v2.0.1/parity-2.0.1-osx.tar.gz"
+  version "2.0.1"
 
   depends_on "git"
   depends_on "heroku-toolbelt"
-  depends_on "postgres"
+  depends_on "postgres" => :optional
 
   def install
     lib.install Dir["lib/*"]
@@ -21,7 +21,7 @@ class Parity < Formula
 
     depends_on "git"
     depends_on "heroku-toolbelt"
-    depends_on "postgres"
+    depends_on "postgres" => :recommended
   end
 
   test do


### PR DESCRIPTION
- resolves packaging and permissioning issues on macOS
- make PostgreSQL a recommended rather than hard dependency to avoid
  forcing users to update their version when it's not relevant for
  parity use