### PR TITLE
Fix: Add fully scope for system call to fix brew audit warning

### DIFF
--- a/Formula/rcm.rb
+++ b/Formula/rcm.rb
@@ -11,6 +11,6 @@ class Rcm < Formula
   end
 
   test do
-    system "lsrc"
+    system "#{bin}/lsrc"
   end
 end


### PR DESCRIPTION
This pull-requests fixes the warning message from `brew audit --strict rcm` by adding the fully scope to the system call in the test.