### PR TITLE
Allow installation of Parity from HEAD

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -2,6 +2,7 @@ require "formula"
 
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
+  head "https://github.com/thoughtbot/parity.git"
   sha256 "693e2f05ba5eccca7a526be7ae0afc25dcddea6ad55cd998bc9b6935920920f0"
   url "https://github.com/thoughtbot/parity/releases/download/v2.0.1/parity-2.0.1-osx.tar.gz"
   version "2.0.1"


### PR DESCRIPTION
This change allows us to test the Homebrew formula against whatever we
have on master on GitHub.

`brew install parity --HEAD`

Using this approach allows us to pre-test new versions without
overwriting/remaking the `development` release on GitHub.