### PR TITLE
Move Liftoff tap to external org

### DIFF
--- a/Formula/liftoff.rb
+++ b/Formula/liftoff.rb
@@ -8,6 +8,7 @@ class Liftoff < Formula
   depends_on 'xcproj' => :recommended
 
   def install
+    opoo 'This tap for Liftoff has been deprecated and will no longer be updated! Please move to the new tap at liftoffcli/formula as soon as possible.'
     prefix.install 'defaults', 'templates', 'vendor'
     prefix.install 'lib' => 'rubylib'
 

--- a/Formula/liftoff.rb
+++ b/Formula/liftoff.rb
@@ -1,8 +1,8 @@
 require 'formula'
 
 class Liftoff < Formula
-  homepage 'https://github.com/thoughtbot/liftoff'
-  url 'http://thoughtbot.github.io/liftoff/Liftoff-1.8.1.tar.gz'
+  homepage 'https://github.com/liftoffcli/liftoff'
+  url 'http://liftoffcli.github.io/liftoff/Liftoff-1.8.1.tar.gz'
   sha256 '4f60770640cef4d510fccb66fb36e7418487f013070d2a7fcce3b450638c1566'
 
   depends_on 'xcproj' => :recommended

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Tap this repository:
 Install the packages it contains like any other Homebrew package:
 
     brew install gitsh
-    brew install liftoff
     brew install parity
     brew install rcm
 
@@ -22,6 +21,5 @@ Install the packages it contains like any other Homebrew package:
 Submit pull requests against the respective repos:
 
 * [gitsh](https://github.com/thoughtbot/gitsh)
-* [liftoff](https://github.com/thoughtbot/liftoff)
 * [parity](https://github.com/thoughtbot/parity)
 * [rcm](https://github.com/thoughtbot/rcm)


### PR DESCRIPTION
We're spinning this off into its own thing, so the tap/source now lives
outside of the thoughtbot org.