### PR TITLE
Fix the extra space in the SHA256 hash

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -3,7 +3,7 @@ require "formula"
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
   head "https://github.com/thoughtbot/parity.git"
-  sha256 "600e81753d6b5b765371fe135883bfdb92812e0dfd7cb6eb8078ab7439389617 "
+  sha256 "600e81753d6b5b765371fe135883bfdb92812e0dfd7cb6eb8078ab7439389617"
   url "https://github.com/thoughtbot/parity/archive/v3.0.0.tar.gz"
   version "3.0.0"
 


### PR DESCRIPTION
```
 $ brew upgrade parity
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/cask).
No changes to formulae.

==> Upgrading 1 outdated package:
thoughtbot/formulae/parity 2.4.0 -> 3.0.0
==> Upgrading thoughtbot/formulae/parity
==> Downloading https://github.com/thoughtbot/parity/archive/v3.0.0.tar.gz
==> Downloading from https://codeload.github.com/thoughtbot/parity/tar.gz/v3.0.0
######################################################################## 100.0%
Error: An exception occurred within a child process:
  ChecksumMismatchError: SHA256 mismatch
Expected: 600e81753d6b5b765371fe135883bfdb92812e0dfd7cb6eb8078ab7439389617
Actual: 600e81753d6b5b765371fe135883bfdb92812e0dfd7cb6eb8078ab7439389617
Archive: /Users/johnpaul/Library/Caches/Homebrew/downloads/0f90da1fa245d373f2c2f4306456fed77f434d55a188cf590b3d45bda330682c--parity-3.0.0.tar.gz
To retry an incomplete download, remove the file above.
```