### PR TITLE
Bump parity 3.0.1 -> 3.1.0

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -3,8 +3,8 @@ require "formula"
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
   head "https://github.com/thoughtbot/parity.git"
-  sha256 "2f4b600b4d8d88507c632e8b994d3827a3c5ff577b3f997c0e57d81229fe22e7"
-  url "https://github.com/thoughtbot/parity/archive/3.0.1.tar.gz"
+  sha256 "c804bca89d99f8cfacde6098959a198b9ef347ad8ce40759133fd766206d7b04"
+  url "https://github.com/thoughtbot/parity/archive/3.1.0.tar.gz"
 
   depends_on "git"
   depends_on "heroku/brew/heroku" => :recommended


### PR DESCRIPTION
https://github.com/thoughtbot/parity/releases/tag/3.1.0

```
shasum -a 256 parity-3.1.0.tar.gz
c804bca89d99f8cfacde6098959a198b9ef347ad8ce40759133fd766206d7b04  parity-3.1.0.tar.gz
```