### PR TITLE
Bump Parity 3.1.0 -> 3.2.0

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -3,8 +3,8 @@ require "formula"
 class Parity < Formula
   homepage "https://github.com/thoughtbot/parity"
   head "https://github.com/thoughtbot/parity.git"
-  sha256 "c804bca89d99f8cfacde6098959a198b9ef347ad8ce40759133fd766206d7b04"
-  url "https://github.com/thoughtbot/parity/archive/3.1.0.tar.gz"
+  sha256 "fb4d72e7d84d7849c25589bf718580b46117f992f2b8b9d22a208bfad6d60a19"
+  url "https://github.com/thoughtbot/parity/archive/v3.2.0.tar.gz"
 
   depends_on "git"
   depends_on "heroku/brew/heroku" => :recommended


### PR DESCRIPTION
```
❯ shasum ~/Downloads/parity-3.2.0.tar.gz
18f75daf1878e4c6ef06dd60b6752223b9f9106f  /Users/geoff/Downloads/parity-3.2.0.tar.gz
```