### PR TITLE
parity: use heroku tap to install dependency

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -9,7 +9,7 @@ class Parity < Formula
     url "https://github.com/thoughtbot/parity/releases/tag/development-20171006a"
   end
 
-  depends_on "heroku-toolbelt" => :recommended
+  depends_on "heroku/brew/heroku" => :recommended
   depends_on "postgresql" => :recommended
 
   def install


### PR DESCRIPTION
I'm not really sure why this dependency was rolled back to the homebrew core heroku formula, that formula doesn't exist anymore.

Heroku cli was removed from core
https://github.com/Homebrew/homebrew-core/pull/33233

This was fixed in the same way here
https://github.com/thoughtbot/homebrew-formulae/pull/53

But it was rolled back here
https://github.com/thoughtbot/homebrew-formulae/commit/47f2be18246faf9417085f0be476eb1e3a13c4e0
