### PR TITLE
Release parity 3.3.0

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -1,8 +1,8 @@
 class Parity < Formula
   desc "Shell commands for environment parity for Heroku apps"
   homepage "https://github.com/thoughtbot/parity"
-  url "https://github.com/thoughtbot/parity/archive/v3.2.0.tar.gz"
-  sha256 "fb4d72e7d84d7849c25589bf718580b46117f992f2b8b9d22a208bfad6d60a19"
+  url "https://github.com/thoughtbot/parity/archive/v3.3.0.tar.gz"
+  sha256 "a0f22b73482cf3117d17b1176fe83f0ea510456ad0333e56339129059c25c845"
   head "https://github.com/thoughtbot/parity.git"
 
   devel do


### PR DESCRIPTION
This release is out in the gh repo - https://github.com/thoughtbot/parity/releases/tag/3.3.0 - and as a gem - https://rubygems.org/gems/parity/versions/0.0.1 - this bumps homebrew formula as well.