### PR TITLE
Remove `devel` block from Parity formula

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -5,10 +5,6 @@ class Parity < Formula
   sha256 "a0f22b73482cf3117d17b1176fe83f0ea510456ad0333e56339129059c25c845"
   head "https://github.com/thoughtbot/parity.git"
 
-  devel do
-    url "https://github.com/thoughtbot/parity/releases/tag/development-20171006a"
-  end
-
   depends_on "heroku/brew/heroku" => :recommended
   depends_on "postgresql" => :recommended
 


### PR DESCRIPTION
Running brew commands like `brew update` or `brew upgrade` with this tap
prints this warning:

    Warning: Calling 'devel' blocks in formulae is deprecated! Use 'head' blocks or @-versioned formulae instead.
    Please report this issue to the thoughtbot/formulae tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
      /usr/local/Homebrew/Library/Taps/thoughtbot/homebrew-formulae/Formula/parity.rb:8

Since the `devel` block points to a version from 2017, it looks like the easiest fix is simply to remove it.