### PR TITLE
rcm is part of Homebrew-core

### DIFF
--- a/Formula/rcm.rb
+++ b/Formula/rcm.rb
@@ -5,6 +5,7 @@ class Rcm < Formula
   sha256 "935524456f2291afa36ef815e68f1ab4a37a4ed6f0f144b7de7fb270733e13af"
 
   def install
+    opoo 'This tap for rcm has been deprecated and will no longer be updated! Please move to the official Homebrew Core release as soon as possible.'
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Install the packages it contains like any other Homebrew package:
 
     brew install gitsh
     brew install parity
-    brew install rcm
 
 ## Contributing
 
@@ -22,4 +21,3 @@ Submit pull requests against the respective repos:
 
 * [gitsh](https://github.com/thoughtbot/gitsh)
 * [parity](https://github.com/thoughtbot/parity)
-* [rcm](https://github.com/thoughtbot/rcm)


### PR DESCRIPTION
As of April, [rcm is in Homebrew-core]. Woo! Thanks to Stephen Groat for
doing that.

[rcm is in Homebrew-core]: https://github.com/Homebrew/homebrew-core/pull/53430

Copied verbiage from Liftoff, including the exclamation mark.