### PR TITLE
Fix error building on Homebrew 2.5.1

### DIFF
--- a/Formula/gitsh.rb
+++ b/Formula/gitsh.rb
@@ -44,6 +44,6 @@ class Gitsh < Formula
   end
 
   def set_architecture
-    ENV['READLINE_ARCH'] = "-arch #{MacOS.preferred_arch}"
+    ENV['READLINE_ARCH'] = "-arch #{Hardware::CPU.arch}"
   end
 end


### PR DESCRIPTION
Fix in response to error message:
```
Error: An exception occurred within a child process:
  MethodDeprecatedError: Calling MacOS.preferred_arch is disabled! Use Hardware::CPU.arch (or ideally let the compiler handle it) instead.
Please report this issue to the thoughtbot/formulae tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/thoughtbot/homebrew-formulae/Formula/gitsh.rb:47
```

Seems to install fine after fix on my machine (fresh macOS 10.15.6 install).