### PR TITLE
Release complexity 0.4.1

### DIFF
--- a/Formula/complexity.rb
+++ b/Formula/complexity.rb
@@ -1,8 +1,8 @@
 class Complexity < Formula
   desc "Identify complex code"
   homepage "https://github.com/thoughtbot/complexity"
-  url "https://github.com/thoughtbot/complexity/archive/0.3.0.tar.gz"
-  sha256 "d46d060cc6981fd3071064eb9b493466bea4a152ed1c9bfed4f7afc1677327da"
+  url "https://github.com/thoughtbot/complexity/archive/0.4.1.tar.gz"
+  sha256 "3a9719d64379012ebf185cc914dbc9e76897f82c0fefc0d609370f351c812e93"
   license "MIT"
   head "https://github.com/thoughtbot/complexity.git"
 


### PR DESCRIPTION

<details><summary>Fixes <code>cargo install</code> on rustc > 1.5x.x</summary>

```
Last 15 lines from /Users/denny.trebbin/Library/Logs/Homebrew/complexity/01.cargo:
    --> /Users/denny.trebbin/Library/Caches/Homebrew/cargo_cache/registry/src/github.com-1ecc6299db9ec823/lexical-core-0.7.4/src/atof/algorithm/math.rs:1254:17
     |
1254 |     let div = n / bits;
     |                 ^ no implementation for `usize / u32`
     |
     = help: the trait `Div<u32>` is not implemented for `usize`

Some errors have detailed explanations: E0277, E0308.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `lexical-core` due to 27 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `complexity v0.3.0 (/private/tmp/complexity-20211127-21693-4i1m0x/complexity-0.3.0)`, intermediate artifacts can be found at `/private/tmp/complexity-20211127-21693-4i1m0x/complexity-0.3.0/target`

Caused by:
  build failed

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/thoughtbot/homebrew-formulae/issues
```

</details>