### PR TITLE
Update complexity to 0.4.2 to allow for installation on M1 Macs

### DIFF
--- a/Formula/complexity.rb
+++ b/Formula/complexity.rb
@@ -1,16 +1,22 @@
 class Complexity < Formula
   desc "Identify complex code"
   homepage "https://github.com/thoughtbot/complexity"
-  url "https://github.com/thoughtbot/complexity/archive/0.4.1.tar.gz"
-  sha256 "3a9719d64379012ebf185cc914dbc9e76897f82c0fefc0d609370f351c812e93"
+  url "https://github.com/thoughtbot/complexity/archive/0.4.2.tar.gz"
+  sha256 "735eec89e28fb2dcb8f55c3b3fe3ff39044986eb309b21aa404fdd87d2be91ab"
   license "MIT"
   head "https://github.com/thoughtbot/complexity.git"
 
   depends_on "cmake" => :build
   depends_on "rust" => :build
 
+  option "without-mimalloc", "Use Rust's default allocator (may reduce performance)"
+
   def install
-    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    if build.with? "mimalloc"
+      system "cargo", "install", "--locked", "--root", prefix, "--path", ".", "--features", "mimalloc"
+    else
+      system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    end
   end
 
   test do


### PR DESCRIPTION
What?
=====

This introduces two changes necessary for installation on M1 Macs:

1. Bump complexity to 0.4.2
2. Introduce a compilation option, `--without-mimalloc`, which will
   instead use Rust's default allocator, which was made in the 0.4.2
   release of complexity
   (https://github.com/thoughtbot/complexity/releases/tag/0.4.2)

The underlying issue driving this change is MiMalloc does not work with
ARM architectures currently; this incorporates a change in complexity
allowing for MiMalloc to be an optional feature, which we carry into
this Homebrew formula to pass that configuration option along to folks
installing the tool that way.