### PR TITLE
Use Rust's allocator by default

### DIFF
--- a/Formula/complexity.rb
+++ b/Formula/complexity.rb
@@ -9,7 +9,7 @@ class Complexity < Formula
   depends_on "cmake" => :build
   depends_on "rust" => :build
 
-  option "without-mimalloc", "Use Rust's default allocator (may reduce performance)"
+  option "with-mimalloc", "Use MiMalloc allocator (Intel-only, may improve performance)"
 
   def install
     if build.with? "mimalloc"


### PR DESCRIPTION
What?
=====

This shifts Homebrew's flags to use Rust's memory allocator by default,
resulting in successful builds for both Intel and Apple ARM architectures.