### PR TITLE
Fix Homebrew postgresql deprecation warning [Parity]

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -6,7 +6,7 @@ class Parity < Formula
   head "https://github.com/thoughtbot/parity.git"
 
   depends_on "heroku/brew/heroku" => :recommended
-  depends_on "postgresql" => :recommended
+  depends_on "postgresql@14" => :recommended
 
   def install
     lib.install Dir["lib/*"]


### PR DESCRIPTION
Resolves the Homebrew warning: "Use postgresql@14 instead of deprecated postgresql". The warning appeared frequently when using Homebrew with Parity installed.

<img width="810" alt="Screenshot showing an OS X terminal, displaying multiple lines of the error: Use postgresql@14 instead of deprecated postgresql" src="https://user-images.githubusercontent.com/48354391/191134612-d0022833-4373-4d4a-9962-0014a6f8f69b.png">
