### PR TITLE
Fix deprecation warning about postgresql@14

### DIFF
--- a/Formula/parity.rb
+++ b/Formula/parity.rb
@@ -6,7 +6,7 @@ class Parity < Formula
   head "https://github.com/thoughtbot/parity.git"
 
   depends_on "heroku/brew/heroku" => :recommended
-  depends_on "postgresql@14" => :recommended
+  depends_on "postgresql@15" => :recommended
 
   def install
     lib.install Dir["lib/*"]


### PR DESCRIPTION
When running `brew install parity`, Homebrew shows this message:

    Warning: postgresql@14 has been deprecated because it is not supported upstream! 
    It will be disabled on 2026-11-12.

After changing the formula to depend on `postgresql@15` instead, there is no warning message:

<details>


```
$ brew install parity
==> Fetching downloads for: parity
✔︎ Bottle Manifest postgresql@15 (15.15_1)                                                                                                                                                                 Downloaded   25.9KB/ 25.9KB
✔︎ Formula parity (3.3.0)                                                                                                                                                                                  Verified     10.7KB/ 10.7KB
✔︎ Bottle postgresql@15 (15.15_1)                                                                                                                                                                          Downloaded   17.3MB/ 17.3MB
==> Installing parity from thoughtbot/formulae
==> Installing thoughtbot/formulae/parity dependency: postgresql@15
==> Pouring postgresql@15--15.15_1.arm64_sonoma.bottle.tar.gz
==> /opt/homebrew/Cellar/postgresql@15/15.15_1/bin/initdb --locale=en_US.UTF-8 -E UTF-8 /opt/homebrew/var/postgresql@15
🍺  /opt/homebrew/Cellar/postgresql@15/15.15_1: 3,717 files, 66.3MB
🍺  /opt/homebrew/Cellar/parity/3.3.0: 15 files, 33.5KB, built in 1 second
==> Running `brew cleanup parity`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
```

</details>